### PR TITLE
feat: compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,9 +302,9 @@ dependencies = [
  "bincode",
  "chrono",
  "clap",
+ "glob",
  "predicates",
  "serde",
- "serde_json",
  "tempfile",
  "thiserror",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ walkdir = "2.2.7"
 clap = { version = "4.4.11", features = ["derive", "string"] }
 serde = { version = "1.0.193", features = ["derive"] }
 thiserror = "1.0.52"
-serde_json = "1.0.108"
 chrono = { version = "0.4.31", features = ["serde"] }
 bincode = "1.3.3"
+glob = "0.3.1"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -273,8 +273,8 @@ fn compaction() -> Result<()> {
     };
 
     let mut current_size = dir_size();
-    for iter in 0..1000 {
-        for key_id in 0..1000 {
+    for iter in 0..100 {
+        for key_id in 0..100 {
             let key = format!("key{}", key_id);
             let value = format!("{}", iter);
             store.set(key, value)?;
@@ -290,7 +290,7 @@ fn compaction() -> Result<()> {
         drop(store);
         // reopen and check content.
         let mut store = KvStore::open(temp_dir.path())?;
-        for key_id in 0..1000 {
+        for key_id in 0..100 {
             let key = format!("key{}", key_id);
             assert_eq!(store.get(key)?, Some(format!("{}", iter)));
         }


### PR DESCRIPTION
This has partially been done on `main`, largely because this is a learning project.

---

This works by reading the `keydir` (where our most recent values are stored) and then placing
the values into a new "compacted" log file, updating our latest entries to point to this
new file so that subsequent reads will be able to find the correct values by seeking to the relevant offset.
                                                                                            
When a tombstone value is found (`None`), then the key is removed from the `keydir`. This
is done implicitly by not writing the key into the new file.

